### PR TITLE
Add the packaging metadata to build the pomodoro snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,18 @@
+name: pomodoro
+version: git
+summary:  Command line pomodoro timer
+description: |
+  Command line pomodoro timer, implemented in Go.
+
+grade: stable
+confinement: strict
+
+apps:
+  pomodoro:
+    command: pomodoro
+
+parts:
+  pomodoro:
+    source: .
+    plugin: go
+    go-importpath: github.com/carlmjohnson/pomodoro


### PR DESCRIPTION
This package will let you publish the latest pomodoro in the Ubuntu store, and from there reach many users on all the supported Ubuntu versions, and Linux distributions. You just have to go to https://build.snapcraft.io and enable the automated continuous delivery.