### PR TITLE
Use the dbatbold/beep package for playing a beep, or a short tune

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ _testmain.go
 *.exe
 *.test
 *.prof
+
+pomodoro

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Duration defaults to 25 minutes. Finish may be a duration (e.g. "1h2m3s")
 or a target time (e.g. "1:00pm" or "13:02:03"). Durations may be expressed
 as integer minutes (e.g. "15") or time with units (e.g. "1m30s" or "90s").
 
-Chimes system bell at the end of the timer, unless -silence is set.
+Play a bell sound at the end of the timer, unless -silence is set.
 
 ## Screenshots
 ```bash
@@ -36,7 +36,7 @@ Usage of pomodoro:
 Duration defaults to 25 minutes. Durations may be expressed as integer minutes
 (e.g. "15") or time with units (e.g. "1m30s" or "90s").
 
-Chimes system bell at the end of the timer, unless -silence is set.
+Play a bell sound at the end of the timer, unless -silence is set.
   -silence
         Don't ring bell after countdown
   -simple

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/carlmjohnson/pomodoro
 
 go 1.16
 
-require github.com/nsf/termbox-go v1.1.0
+require (
+	github.com/dbatbold/beep v1.0.1
+	github.com/nsf/termbox-go v1.1.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/dbatbold/beep v1.0.1 h1:hcCPZenFTLl0C9i+irSVLy6sCtmBFX2nfJxAqHlKGLU=
+github.com/dbatbold/beep v1.0.1/go.mod h1:nCYglCMeZFCH+ufNXeSjJ5JXN69g8gTPKmCLFBt5zL4=
 github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/nsf/termbox-go v1.1.0 h1:R+GIXVMaDxDQ2VHem5vO5h0mI8ZxLECTUNw1ZzXODzI=

--- a/pomodoro.go
+++ b/pomodoro.go
@@ -2,14 +2,41 @@
 package main
 
 import (
+	"bufio"
 	"flag"
-	"fmt"
 	"os"
+	"strings"
 	"time"
+
+	"github.com/dbatbold/beep"
 )
+
+// A small composition, especially for Pomodoro, by Alexander F. Rødseth, CC0 licensed
+const beepNotes = "A9HRDE DQ C5q3r6i DI qw3rt67io0 DS C6qr6i0[ DS C5r[acn"
+
+func playNotes() error {
+	const (
+		filenameOrEmpty = ""
+		volume          = 100
+	)
+	music := beep.NewMusic(filenameOrEmpty)
+	reader := bufio.NewReader(strings.NewReader(beepNotes))
+	go music.Play(reader, volume)
+	music.Wait()
+	beep.FlushSoundBuffer()
+	return nil
+}
 
 func main() {
 	start := time.Now()
+
+	var hasAudio bool
+	if err := beep.OpenSoundDevice("default"); err == nil { // success
+		if err := beep.InitSoundDevice(); err == nil { // success
+			hasAudio = true
+			defer beep.CloseSoundDevice()
+		}
+	}
 
 	finish, err := waitDuration(start)
 	if err != nil {
@@ -28,17 +55,19 @@ func main() {
 		formatter = formatMinutes
 	}
 
-	fmt.Printf("Start timer for %s.\n\n", wait)
-
 	if *simple {
 		simpleCountdown(finish, formatter)
 	} else {
 		fullscreenCountdown(start, finish, formatter)
 	}
 
-	if !*silence {
-		fmt.Println("\a") // \a is the bell literal.
+	if *silence {
+		return
+	}
+
+	if hasAudio {
+		playNotes()
 	} else {
-		fmt.Println()
+		beep.SendBell()
 	}
 }


### PR DESCRIPTION
Hello Carl Johnson!

When running `pomodoro` in my terminal emulator, no beep was produced. This was probably caused by the specific settings in my terminal emulator. However, I could not let this chance of hacking on pomodoro and adding a beep that was played through the audio system (with a fallback on `\a`, of course), go.

After searching GitHub thoroughly for appropriate packages, [beep](https://github.com/dbatbold/beep) appeared to be the best of the crop, for playing a beep on any system.

Just briefly looking into `beep` did not go as planned, though. I quickly fell into the rabbit hole of using the Beep musical notation, for composing a sweet and short piece of music, specifically for Pomodoro. Behold!

    A9HRDE DQ C5q3r6i DI qw3rt67io0 DS C6qr6i0[ DS C5r[acn

This merry little tune is in the scale of C minor and can be played either with the `beep` command that comes with the `beep` package, like this:

    go install github.com/dbatbold/beep/cmd/beep@latest
    beep -play 'A9HRDE DQ C5q3r6i DI qw3rt67io0 DS C6qr6i0[ DS C5r[acn'
    
Or by building the `pomodoro` command in this branch, and letting the timer complete.

I also removed a `fmt.Print` that I didn't think was useful and snuck it into the same commit. (Don't hate me).

Best regards,
Alexander F. Rødseth